### PR TITLE
close clip on shutdown

### DIFF
--- a/src/main/java/com/github/m0bilebtw/CEngineerCompletedPlugin.java
+++ b/src/main/java/com/github/m0bilebtw/CEngineerCompletedPlugin.java
@@ -138,6 +138,7 @@ public class CEngineerCompletedPlugin extends Plugin
 	{
 		oldExperience.clear();
 		oldAchievementDiaries.clear();
+		soundEngine.close();
 	}
 
 	private void setupOldMaps() {

--- a/src/main/java/com/github/m0bilebtw/SoundEngine.java
+++ b/src/main/java/com/github/m0bilebtw/SoundEngine.java
@@ -67,4 +67,12 @@ public class SoundEngine {
         // underlying line driver
         clip.loop(0);
     }
+
+	public void close()
+	{
+		if (clip != null && clip.isOpen())
+		{
+			clip.close();
+		}
+	}
 }


### PR DESCRIPTION
Clips utilize system resources, and failing to close them can lead to memory leaks.

This fixes a small potential memory leak in the use case where a player has the sound clip play at least once, then shuts down the plugin (or uninstalls it).