### PR TITLE
Announce valuable drops, someone else's purple, empty Barrows chests, superior foes and star layers

### DIFF
--- a/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
+++ b/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
@@ -269,6 +269,43 @@ public interface CEngineerCompletedConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "announceValuableDrops",
+            name = "Announce Valuable Drops",
+            description = "Should C Engineer announce when a kill drops loot worth more than the value below, or an item matching the list below?",
+            section = SECTION_NON_ACHIEVEMENT_ANNOUNCEMENTS,
+            position = 31
+    )
+    default boolean announceValuableDrops() {
+        return true;
+    }
+
+    @Range(
+            min = 0,
+            max = Integer.MAX_VALUE
+    )
+    @ConfigItem(
+            keyName = "valuableDropThreshold",
+            name = "Valuable drop value (gp)",
+            description = "How much the whole drop has to be worth (Grand Exchange price) before it is announced. Set to 0 to only announce the items listed below.",
+            section = SECTION_NON_ACHIEVEMENT_ANNOUNCEMENTS,
+            position = 32
+    )
+    default int valuableDropThreshold() {
+        return 1_000_000;
+    }
+
+    @ConfigItem(
+            keyName = "valuableDropItems",
+            name = "Always valuable items",
+            description = "Comma separated item names that are always announced no matter what they are worth, which is handy for untradeables. Wildcards (*) are supported, e.g. \"vestige, *ancient icon\"",
+            section = SECTION_NON_ACHIEVEMENT_ANNOUNCEMENTS,
+            position = 33
+    )
+    default String valuableDropItems() {
+        return "";
+    }
+
     @ConfigSection(
             name = "General Announcement Settings",
             description = "Settings for other details when achievement sounds play.",

--- a/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
+++ b/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
@@ -236,6 +236,17 @@ public interface CEngineerCompletedConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "announceSuperiorFoe",
+            name = "Announce Superior Foe",
+            description = "Should C Engineer announce when a superior slayer foe appears?",
+            section = SECTION_NON_ACHIEVEMENT_ANNOUNCEMENTS,
+            position = 28
+    )
+    default boolean announceSuperiorFoe() {
+        return true;
+    }
+
     @ConfigSection(
             name = "General Announcement Settings",
             description = "Settings for other details when achievement sounds play.",

--- a/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
+++ b/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
@@ -225,6 +225,17 @@ public interface CEngineerCompletedConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "announceShootingStarLayerMined",
+            name = "Announce Shooting Star Layer Mined",
+            description = "Should C Engineer announce when the crashed star you are at is mined down to its next layer?",
+            section = SECTION_NON_ACHIEVEMENT_ANNOUNCEMENTS,
+            position = 27
+    )
+    default boolean announceShootingStarLayerMined() {
+        return true;
+    }
+
     @ConfigSection(
             name = "General Announcement Settings",
             description = "Settings for other details when achievement sounds play.",

--- a/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
+++ b/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
@@ -247,6 +247,17 @@ public interface CEngineerCompletedConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "announceBarrowsNeverLucky",
+            name = "Announce Barrows Chest Without A Unique",
+            description = "Should C Engineer sympathise when you open a Barrows chest that has no brother's equipment in it?",
+            section = SECTION_NON_ACHIEVEMENT_ANNOUNCEMENTS,
+            position = 29
+    )
+    default boolean announceBarrowsNeverLucky() {
+        return true;
+    }
+
     @ConfigSection(
             name = "General Announcement Settings",
             description = "Settings for other details when achievement sounds play.",

--- a/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
+++ b/src/main/java/com/github/m0bilebtw/CEngineerCompletedConfig.java
@@ -258,6 +258,17 @@ public interface CEngineerCompletedConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "announceRaidUniqueForSomeoneElse",
+            name = "Announce Someone Else's Raid Purple",
+            description = "Should C Engineer announce when a unique drops in your Chambers of Xeric, Theatre of Blood or Tombs of Amascut raid and it goes to someone else?",
+            section = SECTION_NON_ACHIEVEMENT_ANNOUNCEMENTS,
+            position = 30
+    )
+    default boolean announceRaidUniqueForSomeoneElse() {
+        return true;
+    }
+
     @ConfigSection(
             name = "General Announcement Settings",
             description = "Settings for other details when achievement sounds play.",

--- a/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
+++ b/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
@@ -14,6 +14,7 @@ import net.runelite.api.Experience;
 import net.runelite.api.GameState;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
+import net.runelite.api.Player;
 import net.runelite.api.Skill;
 import net.runelite.api.annotations.Varbit;
 import net.runelite.api.events.ActorDeath;
@@ -48,6 +49,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @Slf4j
@@ -63,6 +65,12 @@ public class AnnouncementTriggers {
     private static final String HUNTER_RUMOUR_FULL_INV_DISCARDED_MESSAGE = Text.standardize("You have found a rare piece of the creature! You then discard it as you had no inventory space to pick it up.");
     private static final String FARMING_CONTRACT_MESSAGE = Text.standardize("You've completed a Farming Guild Contract. You should return to Guildmaster Jane.");
     private static final String SUPERIOR_FOE_MESSAGE = Text.standardize("A superior foe has appeared...");
+
+    // Each raid announces its uniques in its own format. A display name is at most 12 characters of letters, digits,
+    // spaces, hyphens and underscores, which is what keeps the loose Chambers of Xeric format from matching everything.
+    private static final Pattern COX_UNIQUE_REGEX = Pattern.compile("^([\\w -]{1,12}) - (.+)$");
+    private static final Pattern TOB_UNIQUE_REGEX = Pattern.compile("^([\\w -]{1,12}) found something special: (.+)$");
+    private static final Pattern TOA_UNIQUE_REGEX = Pattern.compile("^Loot recipient: ([\\w -]{1,12}) - (.+)$");
 
     private static final Set<String> BARROWS_BROTHER_ITEM_NAME_PREFIXES = Set.of(
             "Ahrim's", "Dharok's", "Guthan's", "Karil's", "Torag's", "Verac's"
@@ -295,6 +303,9 @@ public class AnnouncementTriggers {
 
     @Subscribe
     public void onChatMessage(ChatMessage chatMessage) {
+        if (announceIfRaidUniqueWentToSomeoneElse(chatMessage))
+            return;
+
         if (chatMessage.getType() != ChatMessageType.GAMEMESSAGE && chatMessage.getType() != ChatMessageType.SPAM)
             return;
 
@@ -351,6 +362,48 @@ public class AnnouncementTriggers {
             cEngineer.sendChatIfEnabled("Superior foe: appeared.");
             soundEngine.playClip(Sound.SUPERIOR_FOE, executor);
         }
+    }
+
+    /**
+     * @return true if this message was a raid unique announcement, whoever it went to, so that it is not also run
+     * through the regular announcement checks.
+     */
+    private boolean announceIfRaidUniqueWentToSomeoneElse(ChatMessage chatMessage) {
+        ChatMessageType type = chatMessage.getType();
+        if (type != ChatMessageType.GAMEMESSAGE && type != ChatMessageType.FRIENDSCHATNOTIFICATION && type != ChatMessageType.CLAN_MESSAGE)
+            return false;
+
+        String message = Text.removeTags(chatMessage.getMessage());
+
+        String recipient = null;
+        Matcher tobMatcher = TOB_UNIQUE_REGEX.matcher(message);
+        Matcher toaMatcher = TOA_UNIQUE_REGEX.matcher(message);
+        if (tobMatcher.matches()) {
+            recipient = tobMatcher.group(1);
+        } else if (toaMatcher.matches()) {
+            recipient = toaMatcher.group(1);
+        } else if (isInChambersOfXeric()) {
+            Matcher coxMatcher = COX_UNIQUE_REGEX.matcher(message);
+            if (coxMatcher.matches())
+                recipient = coxMatcher.group(1);
+        }
+
+        if (recipient == null)
+            return false;
+
+        if (config.announceRaidUniqueForSomeoneElse() && !isLocalPlayer(recipient)) {
+            cEngineer.sendChatIfEnabled("Purple, but not for me.");
+            soundEngine.playClip(Sound.RAID_UNIQUE_FOR_SOMEONE_ELSE, executor);
+        }
+        return true;
+    }
+
+    private boolean isLocalPlayer(String playerName) {
+        Player localPlayer = client.getLocalPlayer();
+        if (localPlayer == null || localPlayer.getName() == null)
+            return false;
+
+        return Text.standardize(localPlayer.getName()).equals(Text.standardize(playerName));
     }
 
     @Subscribe

--- a/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
+++ b/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
@@ -58,6 +58,7 @@ public class AnnouncementTriggers {
     private static final String HUNTER_RUMOUR_FULL_INV_MESSAGE = Text.standardize("You find a rare piece of the creature! Though without space in your inventory, it drops to the ground.");
     private static final String HUNTER_RUMOUR_FULL_INV_DISCARDED_MESSAGE = Text.standardize("You have found a rare piece of the creature! You then discard it as you had no inventory space to pick it up.");
     private static final String FARMING_CONTRACT_MESSAGE = Text.standardize("You've completed a Farming Guild Contract. You should return to Guildmaster Jane.");
+    private static final String SUPERIOR_FOE_MESSAGE = Text.standardize("A superior foe has appeared...");
 
     private static final Random random = new Random();
 
@@ -331,6 +332,10 @@ public class AnnouncementTriggers {
         } else if (config.announceFarmingContracts() && FARMING_CONTRACT_MESSAGE.equals(standardizedMessage)) {
             cEngineer.sendChatIfEnabled("Farming Contract: completed.");
             soundEngine.playClip(Sound.FARMING_CONTRACT, executor);
+
+        } else if (config.announceSuperiorFoe() && SUPERIOR_FOE_MESSAGE.equals(standardizedMessage)) {
+            cEngineer.sendChatIfEnabled("Superior foe: appeared.");
+            soundEngine.playClip(Sound.SUPERIOR_FOE, executor);
         }
     }
 

--- a/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
+++ b/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
@@ -12,6 +12,8 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Experience;
 import net.runelite.api.GameState;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.Skill;
 import net.runelite.api.annotations.Varbit;
 import net.runelite.api.events.ActorDeath;
@@ -22,6 +24,7 @@ import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetLoaded;
 import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.callback.ClientThread;
@@ -33,6 +36,7 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.NpcLootReceived;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
 import net.runelite.client.util.Text;
 
@@ -59,6 +63,13 @@ public class AnnouncementTriggers {
     private static final String HUNTER_RUMOUR_FULL_INV_DISCARDED_MESSAGE = Text.standardize("You have found a rare piece of the creature! You then discard it as you had no inventory space to pick it up.");
     private static final String FARMING_CONTRACT_MESSAGE = Text.standardize("You've completed a Farming Guild Contract. You should return to Guildmaster Jane.");
     private static final String SUPERIOR_FOE_MESSAGE = Text.standardize("A superior foe has appeared...");
+
+    private static final Set<String> BARROWS_BROTHER_ITEM_NAME_PREFIXES = Set.of(
+            "Ahrim's", "Dharok's", "Guthan's", "Karil's", "Torag's", "Verac's"
+    );
+
+    // Barrows shares its reward container with clue caskets, so it is only ever read while the Barrows reward is open
+    private static final int BARROWS_REWARD_INVENTORY = InventoryID.TRAIL_REWARDINV;
 
     private static final Random random = new Random();
 
@@ -99,6 +110,9 @@ public class AnnouncementTriggers {
 
     @Inject
     private ConfigManager configManager;
+
+    @Inject
+    private ItemManager itemManager;
 
     @Inject
     private SoundEngine soundEngine;
@@ -345,6 +359,40 @@ public class AnnouncementTriggers {
             delayedCoXColLogAnnouncementPending = false;
             announceColLog();
         }
+
+        if (widgetLoaded.getGroupId() == InterfaceID.BARROWS_REWARD) {
+            checkBarrowsRewardForBrothersEquipment();
+        }
+    }
+
+    private void checkBarrowsRewardForBrothersEquipment() {
+        if (!config.announceBarrowsNeverLucky())
+            return;
+
+        ItemContainer rewards = client.getItemContainer(BARROWS_REWARD_INVENTORY);
+        if (rewards == null)
+            return;
+
+        Item[] items = rewards.getItems();
+        if (items.length == 0)
+            return;
+
+        for (Item item : items) {
+            if (isBarrowsBrothersEquipment(item.getId()))
+                return;
+        }
+
+        cEngineer.sendChatIfEnabled("Never lucky.");
+        soundEngine.playClip(Sound.BARROWS_NEVER_LUCKY, executor);
+    }
+
+    private boolean isBarrowsBrothersEquipment(int itemId) {
+        String itemName = itemManager.getItemComposition(itemId).getName();
+        for (String prefix : BARROWS_BROTHER_ITEM_NAME_PREFIXES) {
+            if (itemName.startsWith(prefix))
+                return true;
+        }
+        return false;
     }
 
     private void announceColLog() {

--- a/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
+++ b/src/main/java/com/github/m0bilebtw/announce/AnnouncementTriggers.java
@@ -37,14 +37,17 @@ import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.NpcLootReceived;
+import net.runelite.client.events.PlayerLootReceived;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.ItemStack;
 import net.runelite.client.util.Text;
+import net.runelite.client.util.WildcardMatcher;
 
 import javax.inject.Inject;
 import java.util.Collection;
 import java.util.EnumMap;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
@@ -472,6 +475,48 @@ public class AnnouncementTriggers {
                 soundEngine.playClip(Sound.BRIMSTONE_KEY, executor);
             }
         }
+
+        checkLootForValuableDrop(loot);
+    }
+
+    @Subscribe
+    public void onPlayerLootReceived(PlayerLootReceived playerLootReceived) {
+        checkLootForValuableDrop(playerLootReceived.getItems());
+    }
+
+    private void checkLootForValuableDrop(Collection<ItemStack> loot) {
+        if (!config.announceValuableDrops())
+            return;
+
+        List<String> alwaysValuableItems = Text.fromCSV(config.valuableDropItems());
+        int threshold = config.valuableDropThreshold();
+
+        long totalValue = 0;
+        boolean matchedAlwaysValuableItem = false;
+        for (ItemStack itemStack : loot) {
+            totalValue += (long) itemManager.getItemPrice(itemStack.getId()) * itemStack.getQuantity();
+
+            if (!matchedAlwaysValuableItem && matchesAlwaysValuableItem(itemStack.getId(), alwaysValuableItems))
+                matchedAlwaysValuableItem = true;
+        }
+
+        // A threshold of zero means the player only wants the items they listed, rather than every last bone and feather
+        if (matchedAlwaysValuableItem || (threshold > 0 && totalValue >= threshold)) {
+            cEngineer.sendChatIfEnabled("Valuable drop: completed.");
+            soundEngine.playClip(Sound.VALUABLE_DROP, executor);
+        }
+    }
+
+    private boolean matchesAlwaysValuableItem(int itemId, List<String> alwaysValuableItems) {
+        if (alwaysValuableItems.isEmpty())
+            return false;
+
+        String itemName = itemManager.getItemComposition(itemId).getName();
+        for (String itemNamePattern : alwaysValuableItems) {
+            if (WildcardMatcher.matches(itemNamePattern, itemName))
+                return true;
+        }
+        return false;
     }
 
     @Subscribe

--- a/src/main/java/com/github/m0bilebtw/qol/QualityOfLifeTriggers.java
+++ b/src/main/java/com/github/m0bilebtw/qol/QualityOfLifeTriggers.java
@@ -7,22 +7,50 @@ import com.github.m0bilebtw.sound.Sound;
 import com.github.m0bilebtw.sound.SoundEngine;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.GameState;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.Player;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.ActorDeath;
+import net.runelite.api.events.GameObjectDespawned;
+import net.runelite.api.events.GameObjectSpawned;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.api.events.GameTick;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.gameval.InventoryID;
 import net.runelite.api.gameval.ItemID;
+import net.runelite.api.gameval.ObjectID;
 import net.runelite.api.gameval.VarbitID;
 import net.runelite.client.eventbus.Subscribe;
 
 import javax.inject.Inject;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
 public class QualityOfLifeTriggers {
     private static final int INFERNAL_PARCHMENT_WARN_COOLDOWN = 36;
     private static final Set<Integer> BOUNTY_HUNTER_REGIONS = Set.of(13374, 13375, 13376, 13630, 13631, 13632, 13886, 13887, 13888);
+
+    /**
+     * A crashed star is a single object that swaps to the next object id every time its current layer is mined out,
+     * counting down from size 9 to size 1, so the size doubles up as the layer we are currently mining.
+     */
+    private static final Map<Integer, Integer> STAR_OBJECT_ID_TO_SIZE = Map.of(
+            ObjectID.STAR_SIZE_NINE_STAR, 9,
+            ObjectID.STAR_SIZE_EIGHT_STAR, 8,
+            ObjectID.STAR_SIZE_SEVEN_STAR, 7,
+            ObjectID.STAR_SIZE_SIX_STAR, 6,
+            ObjectID.STAR_SIZE_FIVE_STAR, 5,
+            ObjectID.STAR_SIZE_FOUR_STAR, 4,
+            ObjectID.STAR_SIZE_THREE_STAR, 3,
+            ObjectID.STAR_SIZE_TWO_STAR, 2,
+            ObjectID.STAR_SIZE_ONE_STAR, 1
+    );
+
+    /** Only announce for a star we are actually standing at, rather than one that happens to be in view. */
+    private static final int STAR_NEARBY_TILES = 5;
 
     @Inject
     private Client client;
@@ -46,11 +74,78 @@ public class QualityOfLifeTriggers {
 
     private int lastInfernalParchmentWarningTick = -1;
 
+    private WorldPoint knownStarLocation = null;
+    private int knownStarSize = -1;
+    private boolean knownStarDespawned = false;
+
     @Subscribe
     public void onVarbitChanged(VarbitChanged varbitChanged) {
         if (varbitChanged.getVarbitId() == VarbitID.INSIDE_WILDERNESS && varbitChanged.getValue() == 1) {
             checkAndWarnForUnparchmentedInfernal();
         }
+    }
+
+    @Subscribe
+    public void onGameStateChanged(GameStateChanged gameStateChanged) {
+        if (gameStateChanged.getGameState() != GameState.LOGGED_IN) {
+            forgetKnownStar();
+        }
+    }
+
+    @Subscribe
+    public void onGameObjectSpawned(GameObjectSpawned gameObjectSpawned) {
+        GameObject gameObject = gameObjectSpawned.getGameObject();
+        Integer size = STAR_OBJECT_ID_TO_SIZE.get(gameObject.getId());
+        if (size == null)
+            return;
+
+        WorldPoint location = gameObject.getWorldLocation();
+
+        // Mining out a layer despawns the old star object and spawns the next one down within the same tick, so a
+        // smaller star appearing where we already knew of a bigger one means its layer was just mined through.
+        if (location.equals(knownStarLocation) && size < knownStarSize && playerIsAtStar(location)) {
+            announceStarLayerMined();
+        }
+
+        knownStarLocation = location;
+        knownStarSize = size;
+        knownStarDespawned = false;
+    }
+
+    @Subscribe
+    public void onGameObjectDespawned(GameObjectDespawned gameObjectDespawned) {
+        GameObject gameObject = gameObjectDespawned.getGameObject();
+        if (STAR_OBJECT_ID_TO_SIZE.containsKey(gameObject.getId()) && gameObject.getWorldLocation().equals(knownStarLocation)) {
+            knownStarDespawned = true;
+        }
+    }
+
+    @Subscribe
+    public void onGameTick(GameTick gameTick) {
+        // The replacement star spawns in the same tick it despawned, so anything still despawned by now is a star that
+        // has fully depleted or that we have walked away from, and is no longer ours to compare against.
+        if (knownStarDespawned) {
+            forgetKnownStar();
+        }
+    }
+
+    private void announceStarLayerMined() {
+        if (!config.announceShootingStarLayerMined())
+            return;
+
+        cEngineer.sendChatIfEnabled("Shooting star layer: mined.");
+        soundEngine.playClip(Sound.QOL_SHOOTING_STAR_LAYER_MINED, executor);
+    }
+
+    private boolean playerIsAtStar(WorldPoint starLocation) {
+        Player player = client.getLocalPlayer();
+        return player != null && player.getWorldLocation().distanceTo(starLocation) <= STAR_NEARBY_TILES;
+    }
+
+    private void forgetKnownStar() {
+        knownStarLocation = null;
+        knownStarSize = -1;
+        knownStarDespawned = false;
     }
 
     @Subscribe

--- a/src/main/java/com/github/m0bilebtw/sound/Sound.java
+++ b/src/main/java/com/github/m0bilebtw/sound/Sound.java
@@ -24,6 +24,7 @@ public enum Sound {
 
     QOL_NON_PARCH_INFERNAL("Parched_Infernal_r1.wav"),
     QOL_GEM_CRAB_MOVED("gem_crab_moved_r1.wav"),
+    QOL_SHOOTING_STAR_LAYER_MINED("shooting_star_layer_r1.wav"),
 
     EASTER_EGG_STAIRCASE("Staircase_r1.wav"),
     EASTER_EGG_STRAYDOG_BONE("ILoveYou_r2.wav"),

--- a/src/main/java/com/github/m0bilebtw/sound/Sound.java
+++ b/src/main/java/com/github/m0bilebtw/sound/Sound.java
@@ -19,6 +19,7 @@ public enum Sound {
     GRUBBY_KEY("grubby_key_r1.wav"),
     LARRANS_KEY("larrans_key_r1.wav"),
     BRIMSTONE_KEY("brimstone_key_r1.wav"),
+    SUPERIOR_FOE("superior_foe_r1.wav"),
     DEATH("DyingHCIMCompleted_r1.wav"),
     DEATH_TO_C_ENGINEER("Sit_r1.wav"),
 

--- a/src/main/java/com/github/m0bilebtw/sound/Sound.java
+++ b/src/main/java/com/github/m0bilebtw/sound/Sound.java
@@ -19,6 +19,7 @@ public enum Sound {
     GRUBBY_KEY("grubby_key_r1.wav"),
     LARRANS_KEY("larrans_key_r1.wav"),
     BRIMSTONE_KEY("brimstone_key_r1.wav"),
+    BARROWS_NEVER_LUCKY("barrows_never_lucky_r1.wav"),
     SUPERIOR_FOE("superior_foe_r1.wav"),
     DEATH("DyingHCIMCompleted_r1.wav"),
     DEATH_TO_C_ENGINEER("Sit_r1.wav"),

--- a/src/main/java/com/github/m0bilebtw/sound/Sound.java
+++ b/src/main/java/com/github/m0bilebtw/sound/Sound.java
@@ -19,6 +19,7 @@ public enum Sound {
     GRUBBY_KEY("grubby_key_r1.wav"),
     LARRANS_KEY("larrans_key_r1.wav"),
     BRIMSTONE_KEY("brimstone_key_r1.wav"),
+    VALUABLE_DROP("valuable_drop_r1.wav"),
     BARROWS_NEVER_LUCKY("barrows_never_lucky_r1.wav"),
     SUPERIOR_FOE("superior_foe_r1.wav"),
     RAID_UNIQUE_FOR_SOMEONE_ELSE("purple_not_for_me_r1.wav"),

--- a/src/main/java/com/github/m0bilebtw/sound/Sound.java
+++ b/src/main/java/com/github/m0bilebtw/sound/Sound.java
@@ -21,6 +21,7 @@ public enum Sound {
     BRIMSTONE_KEY("brimstone_key_r1.wav"),
     BARROWS_NEVER_LUCKY("barrows_never_lucky_r1.wav"),
     SUPERIOR_FOE("superior_foe_r1.wav"),
+    RAID_UNIQUE_FOR_SOMEONE_ELSE("purple_not_for_me_r1.wav"),
     DEATH("DyingHCIMCompleted_r1.wav"),
     DEATH_TO_C_ENGINEER("Sit_r1.wav"),
 


### PR DESCRIPTION
Five new announcements, four of them from open feature requests.

## Sounds are needed before this can work

The five new `Sound` entries point at files that do not exist on this repo's `sounds` branch yet:

| File | Sound |
| --- | --- |
| `valuable_drop_r1.wav` | `VALUABLE_DROP` |
| `purple_not_for_me_r1.wav` | `RAID_UNIQUE_FOR_SOMEONE_ELSE` |
| `barrows_never_lucky_r1.wav` | `BARROWS_NEVER_LUCKY` |
| `superior_foe_r1.wav` | `SUPERIOR_FOE` |
| `shooting_star_layer_r1.wav` | `QOL_SHOOTING_STAR_LAYER_MINED` |

I put a set on the `sounds` branch of my fork (`OzanKurt/c-engineer-completed`). Up front, so you can judge them properly: **they are AI generated**, using C Engineer's existing sound files and videos as the source. They are finished and ready to drop onto this repo's `sounds` branch if you are happy with both the quality and with AI generated lines standing in for him. If you are not, the code side needs no changes, only real recordings under the same file names. Your call entirely, and no hard feelings if the answer is no.

All five are already padded clear of the 1.491s to 2s window that PipeWire cuts off, and `SoundTest` passes against them.

Worth flagging: the sound files need to be in place before or at the same time as this merges, not after. `downloadFilename` does not check `res.isSuccessful()`, so a 404 from raw.githubusercontent gets written into the `.wav` as if it were audio, and `getFilesToDownload` then skips it forever because the file is "already present". Users on the release would end up with five junk files that never repair themselves, even once the real sounds land, short of deleting them by hand.

That missing status check is pre-existing rather than anything this branch introduces, so I have left it alone here. Happy to send a separate PR that checks the response code and skips writing on failure, if you would like it.

## What each announcement does

**Valuable drops (closes #32)** - prices the whole drop from a kill together, so a pile of mid value loot counts rather than only single big ticket items. Covers both NPC and player kills. Two config options: a gp threshold defaulting to 1,000,000, and a comma separated "always valuable items" list with wildcard support for untradeables the Grand Exchange prices at nothing (e.g. `vestige, *ancient icon`). Setting the threshold to 0 announces only the listed items.

**Someone else's purple (closes #46)** - each raid words its unique announcement differently, so there is a pattern per raid. The Chambers of Xeric wording (`Name - Item`) is loose enough to match ordinary chat, so it is gated behind both the in-raid varbit and a display-name shaped prefix. Recognised raid drop messages are consumed before the regular announcement checks so one message cannot trigger two announcements. Your own purples are left to the existing collection log announcement.

**Barrows chest with no unique (closes #7)** - reads the reward container when the Barrows reward interface opens and checks for any of the six brothers' item name prefixes. The container is shared with clue caskets, so it is only ever inspected while that specific interface is loading.

**Superior foe (closes #45)** - plain chat message match on "A superior foe has appeared...".

**Shooting star layers** - there is no chat message when a crashed star is mined through to its next layer, so this watches the star object swap itself out for the next size down on the same tile. Only fires when you are within five tiles, so stars merely in view are ignored, and the tracked star is forgotten on logout or when it stops respawning within the tick.

## Config

All five default to on, sitting in the existing non-achievement announcements section at positions 27 to 33.

## Testing

Builds clean and `SoundTest` is green on JDK 17. I have not run the triggers through a live game session, so a second pair of eyes on the event handling is welcome, particularly the Chambers of Xeric pattern and the star object tracking.
